### PR TITLE
css-header

### DIFF
--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -376,7 +376,7 @@
   border-top: none;
   border-left: none;
   border-right: none;
-  border-bottom: 0.5px solid $white-color;
+  // border-bottom: 0.5px solid $white-color;
 
   width: 280px;
   height: 20px;
@@ -390,6 +390,11 @@
   position: absolute;
   top: 25%;
   right: 4px;
+
+  &:hover,
+&:focus {
+  transform: scale(1.3);
+}
 }
 
 .input-film {
@@ -398,6 +403,15 @@
   width: 100%;
   background-color: transparent;
   border: none;
+  outline: transparent;
+  border-bottom: 0.5px solid $white-color;
+
+  //  @include transit(border-bottom-color);
+
+  // &:hover,
+  // &:focus {
+  //   border-bottom-color: $line-orange-color;
+  // }
 }
 
 .input-film::placeholder {


### PR DESCRIPTION
Додала мінімальний ховер на іконку пошуку і замінила нижній бордер з лейбла на інпут, щоб був простір для тексту при вводі пошуку